### PR TITLE
Fix issue with open on make not working on some OS

### DIFF
--- a/artisan.plugin.zsh
+++ b/artisan.plugin.zsh
@@ -14,29 +14,19 @@ artisan() {
         return 1
     fi
 
-    if [[ $1 = "make:"* && $ARTISAN_OPEN_ON_MAKE_EDITOR != "" ]]; then
-        # Create a temporarily file that we can use to find any files created by artisan
-        _artisan_laravel_path=`dirname $_artisan`
-        _artisan_make_auto_open_tmp_file="$_artisan_laravel_path/.zsh-artisan-make-auto-open"
-        touch $_artisan_make_auto_open_tmp_file
-    fi
-
     php $_artisan $*
     _artisan_exit_status=$? # Store the exit status so we can return it later
 
-    if [[ -a $_artisan_make_auto_open_tmp_file ]]; then
+    if [[ $1 = "make:"* && $ARTISAN_OPEN_ON_MAKE_EDITOR != "" ]]; then
         # Find and open files created by artisan
+        _artisan_laravel_path=`dirname $_artisan`
         find \
             "$_artisan_laravel_path/app" \
             "$_artisan_laravel_path/tests" \
             "$_artisan_laravel_path/database" \
             -type f \
-            -cnewer $_artisan_make_auto_open_tmp_file \
+            -newermt '-1 seconds' \
             -exec $ARTISAN_OPEN_ON_MAKE_EDITOR {} \; 2>/dev/null
-
-        rm $_artisan_make_auto_open_tmp_file
-        unset _artisan_laravel_path
-        unset _artisan_make_auto_open_tmp_file
     fi
 
     return $_artisan_exit_status

--- a/artisan.plugin.zsh
+++ b/artisan.plugin.zsh
@@ -14,12 +14,12 @@ artisan() {
         return 1
     fi
 
+    _artisan_start_time=`date +%s`
     php $_artisan $*
     _artisan_exit_status=$? # Store the exit status so we can return it later
 
     if [[ $1 = "make:"* && $ARTISAN_OPEN_ON_MAKE_EDITOR != "" ]]; then
         # Find and open files created by artisan
-        _artisan_start_time=`date +%s`
         _artisan_laravel_path=`dirname $_artisan`
         find \
             "$_artisan_laravel_path/app" \

--- a/artisan.plugin.zsh
+++ b/artisan.plugin.zsh
@@ -19,13 +19,14 @@ artisan() {
 
     if [[ $1 = "make:"* && $ARTISAN_OPEN_ON_MAKE_EDITOR != "" ]]; then
         # Find and open files created by artisan
+        _artisan_start_time=`date +%s`
         _artisan_laravel_path=`dirname $_artisan`
         find \
             "$_artisan_laravel_path/app" \
             "$_artisan_laravel_path/tests" \
             "$_artisan_laravel_path/database" \
             -type f \
-            -newermt '-1 seconds' \
+            -newermt "-$((`date +%s` - $_artisan_start_time + 1)) seconds" \
             -exec $ARTISAN_OPEN_ON_MAKE_EDITOR {} \; 2>/dev/null
     fi
 


### PR DESCRIPTION
find -cnewer resolution on some filesystems does
not seem to happen on a less-than-one-second
interval causing no results to be returned
when checked against the temporary file created

find -newermt '-1 seconds' seems to be a better 
solution for returning new files creating within
the last second without the need to create a 
temporary file