### PR TITLE
Added Function prefixes to function definitions

### DIFF
--- a/artisan.plugin.zsh
+++ b/artisan.plugin.zsh
@@ -6,7 +6,7 @@
 # Laravel's artisan command from anywhere within the project. It also
 # adds shell completions that work anywhere artisan can be located.
 
-artisan() {
+function artisan() {
     _artisan=`_artisan_find`
 
     if [ "$_artisan" = "" ]; then
@@ -35,7 +35,7 @@ artisan() {
 
 compdef _artisan_add_completion artisan
 
-_artisan_find() {
+function _artisan_find() {
     # Look for artisan up the file tree until the root directory
     dir=.
     until [ $dir -ef / ]; do
@@ -50,12 +50,12 @@ _artisan_find() {
     return 1
 }
 
-_artisan_add_completion() {
+function _artisan_add_completion() {
     if [ "`_artisan_find`" != "" ]; then
         compadd `_artisan_get_command_list`
     fi
 }
 
-_artisan_get_command_list() {
+function _artisan_get_command_list() {
     artisan --raw --no-ansi list | sed "s/[[:space:]].*//g"
 }


### PR DESCRIPTION
Hey Jess,

Not sure why, haven't developed for zsh, but function defeinitions threw the following errors on my version of zsh.

```
 alex@ari ~ zsh
/Users/alex/.oh-my-zsh/custom/plugins/artisan/artisan.plugin.zsh:9: defining function based on alias `artisan'
/Users/alex/.oh-my-zsh/custom/plugins/artisan/artisan.plugin.zsh:9: parse error near `()'
```

Adding the `function` prefix seemed to fix the error, and didn't seem to have any other side effects.

---

**Zsh Version:** zsh 5.7.1 (x86_64-apple-darwin19.0)
**OS:** MacOS Mojave

---

**Source:**
https://github.com/ohmyzsh/ohmyzsh/issues/6723