### PR TITLE
Run artisan in docker when docker-compose is detected

### DIFF
--- a/artisan.plugin.zsh
+++ b/artisan.plugin.zsh
@@ -16,24 +16,28 @@ function artisan() {
 
     local laravel_path=`dirname $artisan_path`
     local docker_compose_config_path=`find $laravel_path -maxdepth 1 -regex ".*/docker-compose.ya?ml" | head -n1`
-    local docker_compose_service_name=''
+    local artisan_cmd
 
-    if [ "$docker_compose_config_path" != '' ]; then
-        docker_compose_service_name=`docker-compose ps --services 2>/dev/null | grep 'app\|php\|api\|workspace\|laravel\.test\|webhost' | head -n1`
+    if [ "$docker_compose_config_path" = '' ]; then
+        artisan_cmd="php $artisan_path"
+    else
+        if [ "`grep "laravel/sail" $docker_compose_config_path | head -n1`" != '' ]; then
+            artisan_cmd="$laravel_path/vendor/bin/sail artisan"
+        else
+            local docker_compose_cmd=`_docker_compose_cmd`
+            local docker_compose_service_name=`$docker_compose_cmd ps --services 2>/dev/null | grep 'app\|php\|api\|workspace\|laravel\.test\|webhost' | head -n1`
+            if [ -t 1 ]; then
+                artisan_cmd="$docker_compose_cmd exec $docker_compose_service_name php artisan"
+            else
+                # The command is not being run in a TTY (e.g. it's being called by the completion handler below)
+                artisan_cmd="$docker_compose_cmd exec -T $docker_compose_service_name php artisan"
+            fi
+        fi
     fi
 
     local artisan_start_time=`date +%s`
 
-    if [ "$docker_compose_service_name" != '' ]; then
-        if [ -t 1 ]; then
-            docker-compose exec $docker_compose_service_name php artisan $*
-        else
-            # The command is not being run in a TTY (e.g. it's being called by the completion handler below)
-            docker-compose exec -T $docker_compose_service_name php artisan $*
-        fi
-    else
-        php $artisan_path $*
-    fi
+    eval $artisan_cmd $*
 
     local artisan_exit_status=$? # Store the exit status so we can return it later
 
@@ -76,4 +80,13 @@ function _artisan_add_completion() {
 
 function _artisan_get_command_list() {
     artisan --raw --no-ansi list | sed "s/[[:space:]].*//g"
+}
+
+function _docker_compose_cmd() {
+    docker compose &> /dev/null
+    if [ $? = 0 ]; then
+        echo "docker compose"
+    else
+        echo "docker-compose"
+    fi
 }

--- a/artisan.plugin.zsh
+++ b/artisan.plugin.zsh
@@ -19,7 +19,7 @@ function artisan() {
     local docker_compose_service_name=''
 
     if [ "$docker_compose_config_path" != '' ]; then
-        docker_compose_service_name=`docker-compose ps --services 2>/dev/null | grep 'app\|php\|api\|workspace\|laravel\.test' | head -n1`
+        docker_compose_service_name=`docker-compose ps --services 2>/dev/null | grep 'app\|php\|api\|workspace\|laravel\.test\|webhost' | head -n1`
     fi
 
     local artisan_start_time=`date +%s`

--- a/artisan.plugin.zsh
+++ b/artisan.plugin.zsh
@@ -10,7 +10,7 @@ function artisan() {
     local artisan_path=`_artisan_find`
 
     if [ "$artisan_path" = "" ]; then
-        >&2 echo "zsh-artisan: You seem to have upset the delicate internal balance of my housekeeper."
+        >&2 echo "zsh-artisan: artisan not found. Are you in a Laravel directory?"
         return 1
     fi
 

--- a/artisan.plugin.zsh
+++ b/artisan.plugin.zsh
@@ -15,7 +15,7 @@ function artisan() {
     fi
 
     local laravel_path=`dirname $artisan_path`
-    local docker_compose_config_path=`find $laravel_path -maxdepth 1 -regex ".*/docker-compose.ya?ml" | head -n1`
+    local docker_compose_config_path=`find $laravel_path -maxdepth 1 \( -name "docker-compose.yml" -o -name "docker-compose.yaml" \) | head -n1`
     local artisan_cmd
 
     if [ "$docker_compose_config_path" = '' ]; then

--- a/artisan.plugin.zsh
+++ b/artisan.plugin.zsh
@@ -7,55 +7,55 @@
 # adds shell completions that work anywhere artisan can be located.
 
 function artisan() {
-    _artisan=`_artisan_find`
+    local artisan_path=`_artisan_find`
 
-    if [ "$_artisan" = "" ]; then
+    if [ "$artisan_path" = "" ]; then
         >&2 echo "zsh-artisan: You seem to have upset the delicate internal balance of my housekeeper."
         return 1
     fi
 
-    _artisan_laravel_path=`dirname $_artisan`
-    _artisan_docker_compose=`find $_artisan_laravel_path -maxdepth 1 -regex ".*/docker-compose.ya?ml" | head -n1`
-    _artisan_docker_compose_service=''
+    local laravel_path=`dirname $artisan_path`
+    local docker_compose_config_path=`find $laravel_path -maxdepth 1 -regex ".*/docker-compose.ya?ml" | head -n1`
+    local docker_compose_service_name=''
 
-    if [ "$_artisan_docker_compose" != '' ]; then
-        _artisan_docker_compose_service=`docker-compose ps --services 2>/dev/null | grep 'app\|php\|api\|workspace' | head -n1`
+    if [ "$docker_compose_config_path" != '' ]; then
+        docker_compose_service_name=`docker-compose ps --services 2>/dev/null | grep 'app\|php\|api\|workspace' | head -n1`
     fi
 
-    _artisan_start_time=`date +%s`
+    local artisan_start_time=`date +%s`
 
-    if [ "$_artisan_docker_compose_service" != '' ]; then
+    if [ "$docker_compose_service_name" != '' ]; then
         if [ -t 1 ]; then
-            docker-compose exec $_artisan_docker_compose_service php artisan $*
+            docker-compose exec $docker_compose_service_name php artisan $*
         else
             # The command is not being run in a TTY (e.g. it's being called by the completion handler below)
-            docker-compose exec -T $_artisan_docker_compose_service php artisan $*
+            docker-compose exec -T $docker_compose_service_name php artisan $*
         fi
     else
-        php $_artisan $*
+        php $artisan_path $*
     fi
 
-    _artisan_exit_status=$? # Store the exit status so we can return it later
+    local artisan_exit_status=$? # Store the exit status so we can return it later
 
     if [[ $1 = "make:"* && $ARTISAN_OPEN_ON_MAKE_EDITOR != "" ]]; then
         # Find and open files created by artisan
         find \
-            "$_artisan_laravel_path/app" \
-            "$_artisan_laravel_path/tests" \
-            "$_artisan_laravel_path/database" \
+            "$laravel_path/app" \
+            "$laravel_path/tests" \
+            "$laravel_path/database" \
             -type f \
-            -newermt "-$((`date +%s` - $_artisan_start_time + 1)) seconds" \
+            -newermt "-$((`date +%s` - $artisan_start_time + 1)) seconds" \
             -exec $ARTISAN_OPEN_ON_MAKE_EDITOR {} \; 2>/dev/null
     fi
 
-    return $_artisan_exit_status
+    return $artisan_exit_status
 }
 
 compdef _artisan_add_completion artisan
 
 function _artisan_find() {
     # Look for artisan up the file tree until the root directory
-    dir=.
+    local dir=.
     until [ $dir -ef / ]; do
         if [ -f "$dir/artisan" ]; then
             echo "$dir/artisan"

--- a/artisan.plugin.zsh
+++ b/artisan.plugin.zsh
@@ -19,7 +19,7 @@ function artisan() {
     local docker_compose_service_name=''
 
     if [ "$docker_compose_config_path" != '' ]; then
-        docker_compose_service_name=`docker-compose ps --services 2>/dev/null | grep 'app\|php\|api\|workspace' | head -n1`
+        docker_compose_service_name=`docker-compose ps --services 2>/dev/null | grep 'app\|php\|api\|workspace\|laravel\.test' | head -n1`
     fi
 
     local artisan_start_time=`date +%s`


### PR DESCRIPTION
**This is still experimental and I'm currently trialing it with a few different projects to see if I can improve it.**

### The problem

I've been frustrated over the life of this project that I often can't easily use it with projects running inside Docker containers.

Depending on the Docker configuration, some projects and commands work just fine calling artisan on the host machine, but generally this is only when using an sqlite database and when not relying on any additional docker-contained services like Redis. 

For projects that are relying on services in other docker containers (typically managed with `docker-compose`), it's not easy to configure Laravel with a service address that will work both inside and outside the container and also be consistent over time. The docker-assigned IP addresses like `172.21.0.8` are not predictable and can change, and the service hostnames (e.g. `redis`, `db`, etc.) that resolve inside containers do not resolve for the host machine without a lot of effort.

I once wrote [a script that adds entries to my hosts file for each docker container name](https://github.com/jessarcher/dotfiles/blob/master/scripts/docker-hosts.php), but it's a pain to run each time something changes, it requires root, and it relies on the container name rather than the service name, which usually aren't the same and isn't what is *typically* configured by default, so extra `.env` tweaking is usually necessary. It's just annoying, especially when working on a variety of projects.

I've tried creating shell aliases for `docker-compose exec app artisan` but it's frustrating to have different commands for docker and non-docker projects, you don't get shell auto-completion, and it only works if the docker-compose service name is "app", which isn't always the case. I've seen "php" and "api" and "workspace" used as well. It also doesn't work with my other shell aliases like `mfs` (`artisan migrate:fresh --seed`) so I end up needing to duplicate them all.

Lately I've just resorted to keeping a shell open inside the docker container and running the commands there. It's generally more reliable, but the shells in a docker image are typically bare-bones and I don't want to mess around creating aliases or installing plugins in ephemeral containers, so I just suffer typing full commands.

So anyway, all that is to say that I've come up with fairly simplistic approach to solve this for *my* docker usage. I feels fairly brittle and it's not opt-in (yet) so I don't want to merge it right now. I would also like to find out more about how other people use artisan with Docker (e.g. Vessel, etc.) and see if I can make work for the majority and fail gracefully if not.

### The approach

Basically all I've done is check for a `docker-compose.ya?ml` file in the same directory as `artisan`, and if found check if there is a service named "app", "php", "api", or "workspace" (Laradock). If found, it then uses `docker-compose exec` to run the artisan command via that service.

I would love some feedback and for anyone that might be interested in this to see if it works for them. It's already drastically improved my quality of life as I can now use artisan and all my shell aliases the same way I normally would. It even works transparently with https://github.com/vim-test/vim-test to call the new `artisan test` inside a container.

It's naturally a little slower when running via `docker-compose exec` and this also impacts shell completion. But I'm wondering whether I can improve the speed bit by removing the `docker-compose ps` call and using an alternative approach to both check that `docker-compose` is installed and what the service names are.