### PR TITLE
Support "src" directories

### DIFF
--- a/artisan.plugin.zsh
+++ b/artisan.plugin.zsh
@@ -36,8 +36,10 @@ function artisan() {
 compdef _artisan_add_completion artisan
 
 function _artisan_find() {
+    # Starts search from "src" folder if it exists
+    if [ -d src ]; then dir=./src; else dir=.; fi
+    
     # Look for artisan up the file tree until the root directory
-    dir=.
     until [ $dir -ef / ]; do
         if [ -f "$dir/artisan" ]; then
             echo "$dir/artisan"


### PR DESCRIPTION
Starts searching for artisan from inside a "src" directory if it exists. It is a fairly common scenario for a Laravel project to be inside a "src", for example. However, this can be modified to support other folders, perhaps as a plugin configuration.