### PR TITLE
docs: add clarification on Oh My Zsh requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ This plugin adds an `artisan` shell command with the following features:
 
 ## Requirements
 
-* [zsh](https://www.zsh.org/)
-* [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh)
+* [Zsh](https://www.zsh.org/)
+* A Zsh package manager (e.g. [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh), [Antigen](https://github.com/zsh-users/antigen), or [Zplug](https://github.com/zplug/zplug))
 * A [Laravel](https://laravel.com/) project
 
 ## Installation
@@ -50,6 +50,14 @@ plugins=(
     composer
     git
 )
+```
+
+### Zplug
+
+Add the following to your `.zshrc`:
+
+```zsh
+zplug "jessarcher/zsh-artisan"
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This plugin adds an `artisan` shell command with the following features:
 ## Requirements
 
 * [Zsh](https://www.zsh.org/)
-* A Zsh package manager (e.g. [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh), [Antigen](https://github.com/zsh-users/antigen), or [Zplug](https://github.com/zplug/zplug))
+* A Zsh package manager (e.g. [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh), [Antigen](https://github.com/zsh-users/antigen), or [zplug](https://github.com/zplug/zplug))
 * A [Laravel](https://laravel.com/) project
 
 ## Installation
@@ -52,7 +52,7 @@ plugins=(
 )
 ```
 
-### Zplug
+### [zplug](https://github.com/zplug/zplug)
 
 Add the following to your `.zshrc`:
 


### PR DESCRIPTION
I've updated this to add a note that basically any Zsh package manager can be used, rather than being a strict dependency on Oh My Zsh. 👍🏻

I also added instructions on using [zplug](https://github.com/zplug/zplug) which is another commonly used plugin manager. 👍🏻