### PR TITLE
Add lando support

### DIFF
--- a/artisan.plugin.zsh
+++ b/artisan.plugin.zsh
@@ -18,20 +18,20 @@ function artisan() {
     local docker_compose_config_path=`find $laravel_path -maxdepth 1 \( -name "docker-compose.yml" -o -name "docker-compose.yaml" \) | head -n1`
     local artisan_cmd
 
-    if [ "$docker_compose_config_path" = '' ]; then
+    if [ -f "$laravel_path/.lando.yml" ]; then
+        artisan_cmd="lando artisan"
+    elif [ "`grep "laravel/sail" $docker_compose_config_path | head -n1`" != '' ]; then
+        artisan_cmd="$laravel_path/vendor/bin/sail artisan"
+    elif [ "$docker_compose_config_path" = '' ]; then
         artisan_cmd="php $artisan_path"
     else
-        if [ "`grep "laravel/sail" $docker_compose_config_path | head -n1`" != '' ]; then
-            artisan_cmd="$laravel_path/vendor/bin/sail artisan"
+        local docker_compose_cmd=`_docker_compose_cmd`
+        local docker_compose_service_name=`$docker_compose_cmd ps --services 2>/dev/null | grep 'app\|php\|api\|workspace\|laravel\.test\|webhost' | head -n1`
+        if [ -t 1 ]; then
+            artisan_cmd="$docker_compose_cmd exec $docker_compose_service_name php artisan"
         else
-            local docker_compose_cmd=`_docker_compose_cmd`
-            local docker_compose_service_name=`$docker_compose_cmd ps --services 2>/dev/null | grep 'app\|php\|api\|workspace\|laravel\.test\|webhost' | head -n1`
-            if [ -t 1 ]; then
-                artisan_cmd="$docker_compose_cmd exec $docker_compose_service_name php artisan"
-            else
-                # The command is not being run in a TTY (e.g. it's being called by the completion handler below)
-                artisan_cmd="$docker_compose_cmd exec -T $docker_compose_service_name php artisan"
-            fi
+            # The command is not being run in a TTY (e.g. it's being called by the completion handler below)
+            artisan_cmd="$docker_compose_cmd exec -T $docker_compose_service_name php artisan"
         fi
     fi
 


### PR DESCRIPTION
This update adds support for Lando.
running `lando artisan` already supports being run from any subdirectory of the lando project, so we don't need to worry about the path.

In this update I've also reordered the if so it reads as

```
if $tool1
  then use tool 1
else if $tool2
  then use tool 2
else if not docker compose
  then run locally
else
  then use docker compose
```

Which means it should be two lines to add any tool in the future