### PR TITLE
Add Fig as an installation method to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ Add the following bundle to your `.zshrc`:
 antigen bundle jessarcher/zsh-artisan
 ```
 
+### [Fig](https://fig.io)
+
+Fig adds apps, shortcuts, and autocomplete to your existing terminal.
+
+Install `artisan` in just one click.
+
+<a href="https://fig.io/plugins/other/zsh-artisan_jessarcher" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
+
 ### Oh-my-zsh
 
 First download the plugin to your oh-my-zsh custom plugin location:


### PR DESCRIPTION
The [Fig Plugin Store](https://fig.io/plugins) supports 1-click install for 400+ shell plugins. We have over 100k users, thousands of whom manage their shell configuration with Fig.

Artisan is already listed in the store, so we'd love to have it listed as a download method on your README.

Thanks so much and please let me know if you have any questions!
