### PR TITLE
fix artisan command args wrapping quotes

### DIFF
--- a/artisan.plugin.zsh
+++ b/artisan.plugin.zsh
@@ -35,9 +35,19 @@ function artisan() {
         fi
     fi
 
+    local artisan_subcmd=$1
+    shift
+
+    local artisan_args=()
+    local arg
+    for arg in $@
+    do
+        artisan_args+=($(printf "%s" "$arg" | sed "s/'/'\\\\''/g;1s/^/'/;\$s/\$/'/"))
+    done
+
     local artisan_start_time=`date +%s`
 
-    eval $artisan_cmd $*
+    eval $artisan_cmd $artisan_subcmd $artisan_args
 
     local artisan_exit_status=$? # Store the exit status so we can return it later
 


### PR DESCRIPTION
So whenever I sent commands like `artisan scout:update "App\Models\MyModel"` my PHP code gets that argument as `AppModelsMyModel` because this zsh plugin removes the quotes

So this PR fixes the wrong behaviour [by using this](https://unix.stackexchange.com/a/445477/230630)