### PR TITLE
Allow to use different with php versions

### DIFF
--- a/artisan.plugin.zsh
+++ b/artisan.plugin.zsh
@@ -19,7 +19,7 @@ function artisan() {
     local artisan_cmd
 
     if [ "$docker_compose_config_path" = '' ]; then
-        artisan_cmd="php $artisan_path"
+        artisan_cmd="$artisan_path"
     else
         if [ "`grep "laravel/sail" $docker_compose_config_path | head -n1`" != '' ]; then
             artisan_cmd="$laravel_path/vendor/bin/sail artisan"


### PR DESCRIPTION
Not sure if it's feasible but it may be good option instead of calling 'php' on line 22, let the artisan to pick php version.
This way by changing PHP path in artisan file I can decide myself which php version should be used.

This might be useful if I want to call artisan with an php alias like `php72 artisan` or `php80 artisan`