### PR TITLE
Fix multi word variable bug

### DIFF
--- a/artisan.plugin.zsh
+++ b/artisan.plugin.zsh
@@ -25,7 +25,7 @@ function artisan() {
             artisan_cmd="$laravel_path/vendor/bin/sail artisan"
         else
             local docker_compose_cmd=`_docker_compose_cmd`
-            local docker_compose_service_name=`$docker_compose_cmd ps --services 2>/dev/null | grep 'app\|php\|api\|workspace\|laravel\.test\|webhost' | head -n1`
+            local docker_compose_service_name=`$=docker_compose_cmd ps --services 2>/dev/null | grep 'app\|php\|api\|workspace\|laravel\.test\|webhost' | head -n1`
             if [ -t 1 ]; then
                 artisan_cmd="$docker_compose_cmd exec $docker_compose_service_name php artisan"
             else


### PR DESCRIPTION
This was creating an issue where `docker compose` was being read as a single variable with a space, rather than two separate words. This can be fixed in a few ways, such as putting something like `setopt shwordsplit` in the user's zshrc, but that requires every user to have that set. Interestingly enough, eval doesn't seem to have this same issue, only the backticks and $() do.